### PR TITLE
Default showWebviewLoader to true only on Android

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import React, { PropTypes, PureComponent } from 'react';
-import { View, WebView, ActivityIndicator } from 'react-native';
+import { View, Platform, WebView, ActivityIndicator } from 'react-native';
 
 export default class SVGImage extends PureComponent {
   static propTypes = {
@@ -14,7 +14,7 @@ export default class SVGImage extends PureComponent {
   static defaultProps = {
     style: {},
     source: { uri: '' },
-    showWebviewLoader: true,
+    showWebviewLoader: Platform.OS === 'android',
     height: null,
   };
 


### PR DESCRIPTION
It doesn't work properly on iOS. See: http://stackoverflow.com/questions/43812612/react-native-expo-svg-wont-render-on-ios-device